### PR TITLE
Update SAP Commerce to 2205

### DIFF
--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "temurin"
+          distribution: "adopt"
           java-version: "11"
           cache: "gradle"
       - name: Validate Gradle wrapper

--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["2011.20", "2005.25"]
+        version: ["2105.12", "2011.22", "2005.27"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: "temurin"
-          java-version: "11"
+          distribution: "adopt"
+          java-version: "17"
           cache: "gradle"
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/buildandtest_singleextension.yml
+++ b/.github/workflows/buildandtest_singleextension.yml
@@ -36,11 +36,11 @@ jobs:
           ref: ${{ inputs.ref }}
           path: "core-customize/hybris/bin/custom/sapcxtools/${{ inputs.extension }}"
           fetch-depth: 1
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: "temurin"
-          java-version: "11"
+          distribution: "adopt"
+          java-version: "17"
           cache: "gradle"
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: "temurin"
-          java-version: "11"
+          distribution: "adopt"
+          java-version: "17"
           cache: "gradle"
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -20,11 +20,11 @@ jobs:
         extension: ["sapcommercetoolkit", "sapcxbackoffice", "sapcxreporting"]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: "temurin"
-          java-version: "11"
+          distribution: "adopt"
+          java-version: "17"
           cache: "gradle"
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.diffplug.spotless") version("6.0.4")
+    id("com.diffplug.spotless") version("6.8.0")
 }
 
 repositories {
@@ -15,6 +15,7 @@ spotless {
         targetExclude("core-customize/hybris/bin/custom/sapcxtools/**/gensrc/**")
         importOrderFile(importOrderConfigFile)
         eclipse().configFile(javaFormatterConfigFile)
+        removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()
     }

--- a/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/src/tools/sapcx/commerce/toolkit/email/attachments/AbstractHtmlEmailAttachmentBuilder.java
+++ b/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/src/tools/sapcx/commerce/toolkit/email/attachments/AbstractHtmlEmailAttachmentBuilder.java
@@ -2,7 +2,6 @@ package tools.sapcx.commerce.toolkit.email.attachments;
 
 import javax.activation.DataSource;
 
-import org.apache.commons.mail.EmailAttachment;
 import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.HtmlEmail;
 

--- a/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/testsrc/tools/sapcx/commerce/toolkit/email/HtmlEmailBuilderTests.java
+++ b/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/testsrc/tools/sapcx/commerce/toolkit/email/HtmlEmailBuilderTests.java
@@ -3,13 +3,11 @@ package tools.sapcx.commerce.toolkit.email;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
-import java.util.Map;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
@@ -22,12 +20,10 @@ import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.HtmlEmail;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.BeanUtils;
 
 import tools.sapcx.commerce.toolkit.email.attachments.HtmlEmailAttachmentBuilders;
 import tools.sapcx.commerce.toolkit.testing.itemmodel.InMemoryModelFactory;
 import tools.sapcx.commerce.toolkit.testing.testdoubles.email.HtmlEmailGeneratorFake;
-import tools.sapcx.commerce.toolkit.testing.utils.ReflectionUtils;
 
 @UnitTest
 public class HtmlEmailBuilderTests {

--- a/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/testsrc/tools/sapcx/commerce/toolkit/email/HtmlEmailGeneratorDefaultMethodsTests.java
+++ b/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/testsrc/tools/sapcx/commerce/toolkit/email/HtmlEmailGeneratorDefaultMethodsTests.java
@@ -1,7 +1,6 @@
 package tools.sapcx.commerce.toolkit.email;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -10,7 +9,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.mail.MessagingException;
-import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMultipart;
 
@@ -19,7 +17,6 @@ import org.apache.commons.mail.HtmlEmail;
 import org.junit.Before;
 import org.junit.Test;
 
-import tools.sapcx.commerce.toolkit.email.attachments.HtmlEmailAttachmentBuilders;
 import tools.sapcx.commerce.toolkit.testing.testdoubles.email.HtmlEmailGeneratorFake;
 
 public class HtmlEmailGeneratorDefaultMethodsTests {

--- a/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/testsrc/tools/sapcx/commerce/toolkit/testing/itemmodel/InMemoryItemModelContext.java
+++ b/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/testsrc/tools/sapcx/commerce/toolkit/testing/itemmodel/InMemoryItemModelContext.java
@@ -1,12 +1,10 @@
 package tools.sapcx.commerce.toolkit.testing.itemmodel;
 
-import static org.apache.commons.collections4.SetUtils.emptyIfNull;
 import static tools.sapcx.commerce.toolkit.testing.itemmodel.InMemoryModelFactory.attributeFor;
 import static tools.sapcx.commerce.toolkit.testing.itemmodel.InMemoryModelFactory.localizedAttributeFor;
 
 import java.io.ObjectStreamException;
 import java.util.*;
-import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 

--- a/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/testsrc/tools/sapcx/commerce/toolkit/testing/testdoubles/models/ProductBuilder.java
+++ b/core-customize/hybris/bin/custom/sapcxtools/sapcommercetoolkit/testsrc/tools/sapcx/commerce/toolkit/testing/testdoubles/models/ProductBuilder.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import de.hybris.platform.category.model.CategoryModel;
 import de.hybris.platform.core.model.product.ProductModel;
 
 import tools.sapcx.commerce.toolkit.testing.itemmodel.InMemoryModelFactory;

--- a/core-customize/hybris/bin/custom/sapcxtools/sapcxreporting/resources/sapcxreporting-items.xml
+++ b/core-customize/hybris/bin/custom/sapcxtools/sapcxreporting/resources/sapcxreporting-items.xml
@@ -34,7 +34,7 @@
             <deployment table="cxqryrprt" typecode="31151"/>
             <attributes>
                 <attribute qualifier="id" type="java.lang.String">
-                    <persistence type="property" />
+                    <persistence type="property"/>
                     <modifiers unique="true" />
                 </attribute>
                 <attribute qualifier="title" type="localized:java.lang.String">
@@ -56,6 +56,9 @@
                         </columntype>
                         <columntype database="sqlserver">
                             <value>TEXT</value>
+                        </columntype>
+                        <columntype database="sap">
+                            <value>NCLOB</value>
                         </columntype>
                     </persistence>
                 </attribute>

--- a/core-customize/hybris/bin/custom/sapcxtools/sapcxreporting/src/tools/sapcx/commerce/reporting/generator/ReportGeneratorJobPerformable.java
+++ b/core-customize/hybris/bin/custom/sapcxtools/sapcxreporting/src/tools/sapcx/commerce/reporting/generator/ReportGeneratorJobPerformable.java
@@ -19,7 +19,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import javax.activation.DataSource;
-import javax.mail.internet.InternetAddress;
 import javax.mail.util.ByteArrayDataSource;
 
 import de.hybris.platform.cronjob.enums.CronJobResult;
@@ -28,7 +27,6 @@ import de.hybris.platform.media.services.MimeService;
 import de.hybris.platform.servicelayer.cronjob.AbstractJobPerformable;
 import de.hybris.platform.servicelayer.cronjob.PerformResult;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.BooleanUtils;

--- a/core-customize/manifest.json
+++ b/core-customize/manifest.json
@@ -50,7 +50,7 @@
             ]
         }
     ],
-    "commerceSuiteVersion": "2105.10",
+    "commerceSuiteVersion": "2205.1",
     "extensionPacks": [],
     "extensions": [],
     "properties": [],

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,35 +1,45 @@
+# SAP Commerce Suite 2205
+com.sap.softwaredownloads.commerceSuite.2205.1.downloadUrl=https://softwaredownloads.sap.com/file/0020000000934922022
+com.sap.softwaredownloads.commerceSuite.2205.1.checksum=c625c35d0efb3228a917724d7d87e3a68c51042c058094d19a40b92bb35b2f33
+com.sap.softwaredownloads.commerceSuite.2205.0.downloadUrl=https://softwaredownloads.sap.com/file/0020000000687152022
+com.sap.softwaredownloads.commerceSuite.2205.0.checksum=51916da4c591089b896d5becf7809647b4e5d4398e8679804dd17454b15a3b96
+
 # SAP Commerce Suite 2105
-com.sap.softwaredownloads.commerceSuite.2105.10.downloadUrl=https://softwaredownloads.sap.com/file/0020000000459762022
-com.sap.softwaredownloads.commerceSuite.2105.10.checksum=07ac91c5b1ea3612ddf68c48161e75aa86dd660b2be8837e064280c07b415aba
-com.sap.softwaredownloads.commerceSuite.2105.9.downloadUrl=https://softwaredownloads.sap.com/file/0020000000287542022
-com.sap.softwaredownloads.commerceSuite.2105.9.checksum=b3c0b912373208a3b1d96731206a3e6bda918d3d890bcef74cef817082dc45b4
+com.sap.softwaredownloads.commerceSuite.2105.12.downloadUrl=https://softwaredownloads.sap.com/file/0020000000934802022
+com.sap.softwaredownloads.commerceSuite.2105.12.checksum=a3c6f0ffc64be6c751795d43017d04db07dc5a49b18645c1fd4b5beb18e9e9b0
+com.sap.softwaredownloads.commerceSuite.2105.11.downloadUrl=https://softwaredownloads.sap.com/file/0020000000608992022
+com.sap.softwaredownloads.commerceSuite.2105.11.checksum=94ec550a277bfd9df793b6c2127cc7ca4cf4e740e512419cbaf580c1292e7846
 
 # SAP Commerce Suite 2011
-com.sap.softwaredownloads.commerceSuite.2011.20.downloadUrl=https://softwaredownloads.sap.com/file/0020000000462852022
-com.sap.softwaredownloads.commerceSuite.2011.20.checksum=15ab382974dcebce553f9c11c5d368905f4868580b703445c2a13de12234845d
-com.sap.softwaredownloads.commerceSuite.2011.19.downloadUrl=https://softwaredownloads.sap.com/file/0020000000287472022
-com.sap.softwaredownloads.commerceSuite.2011.19.checksum=ad829567e4f767baf4dc8c9433ad96d8b6fd0e4f6d2f068596182758bfe28db7
+com.sap.softwaredownloads.commerceSuite.2011.22.downloadUrl=https://softwaredownloads.sap.com/file/0020000000934892022
+com.sap.softwaredownloads.commerceSuite.2011.22.checksum=6597b295f6cdf4fe0b557a0f0fca86ab657df4d15cb78b3d80385332a4734d6a
+com.sap.softwaredownloads.commerceSuite.2011.21.downloadUrl=https://softwaredownloads.sap.com/file/0020000000609012022
+com.sap.softwaredownloads.commerceSuite.2011.21.checksum=ee0e6f7e875d2cab73b6d09c433d1877bdb94f0543498c16ca3cc4ef61abf7e8
 
 # SAP Commerce Suite 2005
-com.sap.softwaredownloads.commerceSuite.2005.25.downloadUrl=https://softwaredownloads.sap.com/file/0020000000459742022
-com.sap.softwaredownloads.commerceSuite.2005.25.checksum=e61c671bd5d31f81dda6ed603937b5be789031aaedf6390aab0e0be522e2f337
-com.sap.softwaredownloads.commerceSuite.2005.24.downloadUrl=https://softwaredownloads.sap.com/file/0020000000287492022
-com.sap.softwaredownloads.commerceSuite.2005.24.checksum=62df3ab5e883466abf97fc7b74e8291366d72b0efc7c3f99e82874a30928ad72
+com.sap.softwaredownloads.commerceSuite.2005.27.downloadUrl=https://softwaredownloads.sap.com/file/0020000000934862022
+com.sap.softwaredownloads.commerceSuite.2005.27.checksum=ce85188fef6ba6f2aec5711d405319479bf3f36366cf6d3518b7234bfe872f4f
+com.sap.softwaredownloads.commerceSuite.2005.26.downloadUrl=https://softwaredownloads.sap.com/file/0020000000609022022
+com.sap.softwaredownloads.commerceSuite.2005.26.checksum=18264515577729a7fe02ace0d710127a396465cc64a099bf2228e9b264d7d837
+
+# SAP Commerce Integrations 2205
+com.sap.softwaredownloads.commerceIntegrations.2205.0.downloadUrl=https://softwaredownloads.sap.com/file/0020000000776362022
+com.sap.softwaredownloads.commerceIntegrations.2205.0.checksum=a68b65a3b0fe10e11152b32b1823eb7051fe2f78ca6aa94c99ad14398fdf2b22
 
 # SAP Commerce Integrations 2108
+com.sap.softwaredownloads.commerceIntegrations.2108.4.downloadUrl=https://softwaredownloads.sap.com/file/0020000000934832022
+com.sap.softwaredownloads.commerceIntegrations.2108.4.checksum=d6c3112d55ba8925d593ed989b8d80d8322e310c4a5ca813579a525560081824
 com.sap.softwaredownloads.commerceIntegrations.2108.3.downloadUrl=https://softwaredownloads.sap.com/file/0020000000478112022
 com.sap.softwaredownloads.commerceIntegrations.2108.3.checksum=85426f1fbeb79aaa1b0cae82591e6712b33caebdf10df0af22d42efd0698bed4
-com.sap.softwaredownloads.commerceIntegrations.2108.2.downloadUrl=https://softwaredownloads.sap.com/file/0020000001645522021
-com.sap.softwaredownloads.commerceIntegrations.2108.2.checksum=be97def776bcae60ed31de91d1421da0ae8ec02eca6945467af9eabe3f6c470a
 
 # SAP Commerce Integrations 2102
+com.sap.softwaredownloads.commerceIntegrations.2102.5.downloadUrl=https://softwaredownloads.sap.com/file/0020000000934872022
+com.sap.softwaredownloads.commerceIntegrations.2102.5.checksum=02e7428f73370700cfadefbb41b0df21389e42c927911cf384386f2b62d82fcc
 com.sap.softwaredownloads.commerceIntegrations.2102.4.downloadUrl=https://softwaredownloads.sap.com/file/0020000001508662021
 com.sap.softwaredownloads.commerceIntegrations.2102.4.checksum=0334de7dcc0917cdded35db05623f688205a0012ef96e6bd316a28cf55bb5af6
-com.sap.softwaredownloads.commerceIntegrations.2102.3.downloadUrl=https://softwaredownloads.sap.com/file/0020000001395712021
-com.sap.softwaredownloads.commerceIntegrations.2102.3.checksum=1930e7177c49aec2ada3826b5db5094d90d17f85fb8535b668b2274964e3b16b
 
 # SAP Commerce Integrations 2005
+com.sap.softwaredownloads.commerceIntegrations.2005.6.downloadUrl=https://softwaredownloads.sap.com/file/0020000000934842022
+com.sap.softwaredownloads.commerceIntegrations.2005.6.checksum=7544dd5cd9b1fcce9e37886ed3d1c40bfde06d27ade767886bc25325a8f28bf0
 com.sap.softwaredownloads.commerceIntegrations.2005.5.downloadUrl=https://softwaredownloads.sap.com/file/0020000001165032021
 com.sap.softwaredownloads.commerceIntegrations.2005.5.checksum=b367a36084e63540e39ffbcfd7dbc037e0dd6685bfefc68e0ed60064fcca3de0
-com.sap.softwaredownloads.commerceIntegrations.2005.4.downloadUrl=https://softwaredownloads.sap.com/file/0020000001002682021
-com.sap.softwaredownloads.commerceIntegrations.2005.4.checksum=afe8b7be15eb3d96e44f70e802a22aa34e979c78ab09a38121592ef9144ac079


### PR DESCRIPTION
WIth this PR the commerce suite is updated to 2205.1.

The spotless library was also updated to version 6.8, now supporting the removal of unused imports.